### PR TITLE
fix(build): 移除顶级 await，修复打包报 “Top-level await is not available” 错误

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -388,3 +388,7 @@ Temporary Items
 !.gitignore
 !.gitsubmodules
 
+# tauri
+target
+src-tauri/gen
+src-tauri/target

--- a/src/main.js
+++ b/src/main.js
@@ -15,8 +15,6 @@ window.addEventListener('api-baseurl-updated', (event) => {
   console.log('API BaseURL 已更新:', event.detail?.url)
 })
 
-// 初始化Tauri API
-let isTauri = false
 async function initTauri() {
   try {
     // 尝试导入Tauri core API
@@ -25,47 +23,48 @@ async function initTauri() {
       // 设置全局标识
       window.__TAURI_INVOKE__ = invoke
       window.__TAURI__ = true
-      isTauri = true
       console.log('Tauri API 初始化成功')
+      return true
     }
   } catch (error) {
-    isTauri = false
+    return false
   }
 }
 
-// 立即初始化Tauri
-await initTauri()
+;(async function bootstrap () {
+  // 初始化Tauri API
+  let isTauri = await initTauri()
 
+  // 根据环境创建适当的路由实例
+  const router = createMyRouter(isTauri ? 'hash' : 'history')
 
-// 在 Tauri 环境中设置所有链接在当前窗口打开
-if (isTauri) {
-  // 重写默认的链接打开行为
-  document.addEventListener('click', function(e) {
-    // 查找点击事件中是否包含链接元素
-    let target = e.target;
-    while (target && target !== document) {
-      if (target.tagName === 'A' && target.getAttribute('href')) {
-        // 获取链接地址
-        const href = target.getAttribute('href');
+  const app = createApp(App)
+  app.use(router)
+  app.use(Vant)
+  // 注册像素化插件
+  app.use(pixelatePlugin)
+  app.mount('#app')
 
-        // 如果是外部链接或绝对路径，则在当前窗口打开
-        if (href.startsWith('http') || href.startsWith('//') || href.startsWith('/')) {
-          e.preventDefault();
-          window.location.href = href;
+  // 在 Tauri 环境中设置所有链接在当前窗口打开
+  if (isTauri) {
+    // 重写默认的链接打开行为
+    document.addEventListener('click', function(e) {
+      // 查找点击事件中是否包含链接元素
+      let target = e.target;
+      while (target && target !== document) {
+        if (target.tagName === 'A' && target.getAttribute('href')) {
+          // 获取链接地址
+          const href = target.getAttribute('href');
+
+          // 如果是外部链接或绝对路径，则在当前窗口打开
+          if (href.startsWith('http') || href.startsWith('//') || href.startsWith('/')) {
+            e.preventDefault();
+            window.location.href = href;
+          }
+          break;
         }
-        break;
+        target = target.parentNode;
       }
-      target = target.parentNode;
-    }
-  }, true);
-}
-
-// 根据环境创建适当的路由实例
-const router = createMyRouter(isTauri ? 'hash' : 'history')
-
-const app = createApp(App)
-app.use(router)
-app.use(Vant)
-// 注册像素化插件
-app.use(pixelatePlugin)
-app.mount('#app')
+    }, true);
+  }
+})()


### PR DESCRIPTION
修复 bun run build 时的错误
```
assets/index-!~{001}~.js:149395:0: ERROR: Top-level await is not available in the configured target environment ("chrome87", "edge88", "es2020", "firefox78", "safari14" + 2 overrides)

Top-level await is not available in the configured target environment ("chrome87", "edge88", "es2020", "firefox78", "safari14" + 2 overrides)
149393|
149394|  // 立即初始化Tauri
149395|  await initTauri();
   |  ^
149396|
149397|
```
