### PR TITLE
Docker 构建优化

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 
 FROM base AS install
 COPY package.json bun.lock .
-RUN bun install --frozen-lockfile
+RUN bun install
 
 FROM base AS build
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ COPY package.json bun.lock .
 RUN bun install
 
 FROM base AS build
+ARG BACKEND_URL_ARG=http://localhost:8899
+ENV VITE_DEFAULT_BACKEND_URL=${BACKEND_URL_ARG}
 COPY . .
 COPY --from=install /app/node_modules node_modules
 RUN bun run build

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -10,3 +10,4 @@ respond /health 200 {
 
 root * /app
 file_server
+try_files {path} /index.html

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -1,8 +1,10 @@
 import axios from 'axios'
 
 // 你的服务器地址
+const DEFAULT_FALLBACK_URL = 'http://localhost:8899';
+const VITE_CONFIGURED_DEFAULT_URL = import.meta.env.VITE_DEFAULT_BACKEND_URL || DEFAULT_FALLBACK_URL;
 const getBaseUrl = () => {
-  return localStorage.getItem('baseUrl') || 'http://localhost:8899'
+  return localStorage.getItem('baseUrl') || VITE_CONFIGURED_DEFAULT_URL
 }
 
 const BASE_URL = getBaseUrl()
@@ -13,6 +15,10 @@ const SERVER_URLS = [
   'http://localhost:8899',
   'http://0.0.0.0:8899'
 ]
+
+if (!SERVER_URLS.includes(VITE_CONFIGURED_DEFAULT_URL)) {
+  SERVER_URLS.unshift(VITE_CONFIGURED_DEFAULT_URL)
+}
 
 // 尝试连接多个服务器地址，返回第一个可用的
 export const tryConnectServers = async () => {

--- a/src/components/tailwind/Settings.vue
+++ b/src/components/tailwind/Settings.vue
@@ -1249,7 +1249,8 @@ const saveServerUrl = () => {
 }
 
 // 在script setup部分添加重置功能
-const DEFAULT_SERVER_URL = 'http://localhost:8899'
+const FALLBACK_DEFAULT_SERVER_URL = 'http://localhost:8899';
+const DEFAULT_SERVER_URL = import.meta.env.VITE_DEFAULT_BACKEND_URL || FALLBACK_DEFAULT_SERVER_URL;
 
 // 重置服务器地址
 const resetServerUrl = () => {


### PR DESCRIPTION
修复了 bun install 报错，并解决 env BACKEND_URL 无用的问题（引入 BACKEND_URL_ARG）

docker-compose 用法：
在 frontend 服务的 build 字段中追加 args，传入后端地址

```
  frontend:
    build:
      ...
      args:
        - BACKEND_URL_ARG=https://your.backend.domain/
 ```